### PR TITLE
Fixes test failure under recent versions of Sinon

### DIFF
--- a/source/services/anomaly/lib/test-setup.spec.js
+++ b/source/services/anomaly/lib/test-setup.spec.js
@@ -7,7 +7,7 @@ before(function() {
 });
 
 beforeEach(function() {
-    this.sandbox = sinon.sandbox.create();
+    this.sandbox = sinon.createSandbox();
 });
 
 afterEach(function() {

--- a/source/services/driversafety/lib/test-setup.spec.js
+++ b/source/services/driversafety/lib/test-setup.spec.js
@@ -7,7 +7,7 @@ before(function() {
 });
 
 beforeEach(function() {
-    this.sandbox = sinon.sandbox.create();
+    this.sandbox = sinon.createSandbox();
 });
 
 afterEach(function() {

--- a/source/services/dtc/lib/test-setup.spec.js
+++ b/source/services/dtc/lib/test-setup.spec.js
@@ -7,7 +7,7 @@ before(function() {
 });
 
 beforeEach(function() {
-    this.sandbox = sinon.sandbox.create();
+    this.sandbox = sinon.createSandbox();
 });
 
 afterEach(function() {

--- a/source/services/jitr/test-setup.spec.js
+++ b/source/services/jitr/test-setup.spec.js
@@ -7,7 +7,7 @@ before(function() {
 });
 
 beforeEach(function() {
-    this.sandbox = sinon.sandbox.create();
+    this.sandbox = sinon.createSandbox();
 });
 
 afterEach(function() {

--- a/source/services/marketing/lib/test-setup.spec.js
+++ b/source/services/marketing/lib/test-setup.spec.js
@@ -7,7 +7,7 @@ before(function() {
 });
 
 beforeEach(function() {
-    this.sandbox = sinon.sandbox.create();
+    this.sandbox = sinon.createSandbox();
 });
 
 afterEach(function() {

--- a/source/services/notification/lib/test-setup.spec.js
+++ b/source/services/notification/lib/test-setup.spec.js
@@ -7,7 +7,7 @@ before(function() {
 });
 
 beforeEach(function() {
-    this.sandbox = sinon.sandbox.create();
+    this.sandbox = sinon.createSandbox();
 });
 
 afterEach(function() {

--- a/source/services/vehicle/lib/test-setup.spec.js
+++ b/source/services/vehicle/lib/test-setup.spec.js
@@ -7,7 +7,7 @@ before(function() {
 });
 
 beforeEach(function() {
-    this.sandbox = sinon.sandbox.create();
+    this.sandbox = sinon.createSandbox();
 });
 
 afterEach(function() {


### PR DESCRIPTION
Tests fail out of the box due to an undefined/archaic Sinon method. This PR replaces the depreciated `sinon.sandbox.create()` calls with the equivalent `sinon.createSandbox()` method (which itself is [slightly depreciated](https://sinonjs.org/guides/migrating-to-5.0.html), but should retain backwards compatibility). 

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
